### PR TITLE
The scenario JSON format now requires a purpose per trip.

### DIFF
--- a/R/ab_scenario.R
+++ b/R/ab_scenario.R
@@ -210,7 +210,11 @@ ab_sf_to_json = function(
     tibble::tibble(
       departure = desire_lines_out$departure[i],
       destination = destination,
-      mode = desire_lines_out[[mode_column]][i]
+      mode = desire_lines_out[[mode_column]][i],
+      # Other values at
+      # https://a-b-street.github.io/abstreet/rustdoc/sim/enum.TripPurpose.html.
+      # The simulation doesn't make use of this yet.
+      purpose = "Shopping"
     )
   })
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -142,7 +142,8 @@ The first trip schedule should look something like this, matching [A/B Street's 
               "latitude": 53.8039
             }
           },
-          "mode": "Walk"
+          "mode": "Walk",
+          "purpose": "Shopping"
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ schema](https://a-b-street.github.io/docs/dev/formats/scenarios.html#example).
               "latitude": 53.8039
             }
           },
-          "mode": "Walk"
+          "mode": "Walk",
+          "purpose": "Shopping"
         }
       ]
     }


### PR DESCRIPTION
Hardcoded "shopping" as the default, because this value is only exposed in the UI, not used by anything else yet. https://a-b-street.github.io/abstreet/rustdoc/sim/enum.TripPurpose.html has all values.

Is there a way to run tests here and sanity check I haven't broken anything?