### PR TITLE
Reduce dplyr package dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ BugReports: https://github.com/a-b-street/abstr/issues
 Depends: 
     R (>= 4.0.0)
 Imports: 
-    dplyr (>= 1.0.4),
     jsonlite (>= 1.7.2),
     lwgeom (>= 0.2.5),
     magrittr (>= 2.0.1),

--- a/R/ab_scenario.R
+++ b/R/ab_scenario.R
@@ -77,10 +77,10 @@ ab_scenario = function(houses,
     # supressing messages associated with GEOS ops on unprojected data
     suppressWarnings({
       suppressMessages({
-        origins = houses %>% dplyr::sample_n(size = pop, replace = TRUE)
-        destination_zone = zones %>% dplyr::filter(geo_code == desire_lines$geo_code2[i])
+        origins = houses[sample(1:nrow(houses), size = pop, replace = TRUE), ]
+        destination_zone = zones %>% subset(geo_code == desire_lines$geo_code2[i])
         destination_buildings = buildings[destination_zone, , op = op]
-        destinations = destination_buildings %>% dplyr::sample_n(size = pop, replace = TRUE)
+        destinations = destination_buildings[sample(1:nrow(destination_buildings), size = pop, replace = TRUE), ]
         origin_coords = origins %>% sf::st_centroid() %>% sf::st_coordinates()
         destination_coords = destinations %>% sf::st_centroid() %>% sf::st_coordinates()
         desire_lines_disag = od::odc_to_sf(odc = cbind(origin_coords, destination_coords))

--- a/R/ab_scenario.R
+++ b/R/ab_scenario.R
@@ -77,10 +77,10 @@ ab_scenario = function(houses,
     # supressing messages associated with GEOS ops on unprojected data
     suppressWarnings({
       suppressMessages({
-        origins = houses[sample(1:nrow(houses), size = pop, replace = TRUE), ]
+        origins = houses[sample(nrow(houses), size = pop, replace = TRUE), ]
         destination_zone = zones %>% subset(geo_code == desire_lines$geo_code2[i])
         destination_buildings = buildings[destination_zone, , op = op]
-        destinations = destination_buildings[sample(1:nrow(destination_buildings), size = pop, replace = TRUE), ]
+        destinations = destination_buildings[sample(nrow(destination_buildings), size = pop, replace = TRUE), ]
         origin_coords = origins %>% sf::st_centroid() %>% sf::st_coordinates()
         destination_coords = destinations %>% sf::st_centroid() %>% sf::st_coordinates()
         desire_lines_disag = od::odc_to_sf(odc = cbind(origin_coords, destination_coords))


### PR DESCRIPTION
Base R methods replacing dependency on dplyr. 

**Reproducible example from the abstr package.** 
```R
# Task - Reduce package dependency on dplyr  ------------------------------

# Data & Set-up -----------------------------------------------------------
library(dplyr) 

load(file = "data/leeds_houses.rda")
load(file = "data/leeds_buildings.rda")
load(file = "data/leeds_desire_lines.rda")
load(file = "data/leeds_site_area.rda")
load(file = "data/leeds_zones.rda")

i = 1 
pop = leeds_desire_lines$all_base[i]
cnames = names(leeds_desire_lines)


# Methods -----------------------------------------------------------------

#dplyr sample_n method
origins = leeds_houses %>% dplyr::sample_n(size = pop, replace = TRUE)
#base r sample method 
origins1 = leeds_houses[sample(1:nrow(leeds_houses), size = pop, replace = TRUE), ]

#dplyr filter method
destination_zone = leeds_zones %>% dplyr::filter(geo_code == leeds_desire_lines$geo_code2[i])
#base r filter method
destination_zone1 = leeds_zones %>% subset(geo_code == leeds_desire_lines$geo_code2[i])

````
@Robinlovelace I can't see any other mentions of ```dplyr``` in the codebase.  Let me know if all looks good to you.

