### PR TITLE
Update docs with new abstreet CLI, and don't lead people towards buil…

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -161,9 +161,18 @@ Note: Instead of installing a pre-built version of A/B Street in the first step,
 If you're generating many JSON scenarios, you might not want to manually use A/B Street's user interface to import each file. You can instead run a command.
 
 1.  Install the [latest build](https://a-b-street.github.io/docs/user/index.html) of A/B Street for your platform, or [build from source](https://a-b-street.github.io/docs/tech/dev/index.html).
-2.  From the main A/B Street directory, run this command: `./cli import-scenario --input path/to/scenario.json --map data/system/us/seattle/maps/montlake.bin`
+2.  From the main A/B Street directory, run the following command:
 
-If you're using Windows, you'll instead run `cli.exe`. If you're building from source, `cargo run --release --bin cli -- import-scenario --input path/to/scenario.json --map data/system/us/seattle/maps/montlake.bin`.
+```bash
+./cli import-scenario --input path/to/scenario.json --map data/system/us/seattle/maps/montlake.bin
+```
+
+If you're using Windows, you'll instead run `cli.exe`.
+If you're building from source use the following command:
+
+```bash
+cargo run --release --bin cli -- import-scenario --input path/to/scenario.json --map data/system/us/seattle/maps/montlake.bin
+```
 
 ## Next steps
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -110,7 +110,7 @@ Let's see what is in the file:
 file.edit("ab_scenario.json")
 ```
 
-The first trip schedule should look something like this, matching [A/B Street's schema](https://a-b-street.github.io/docs/tech/dev/formats/).
+The first trip schedule should look something like this, matching [A/B Street's schema](https://a-b-street.github.io/docs/tech/dev/formats/scenarios.html).
 
 ```json
 {
@@ -143,43 +143,27 @@ The first trip schedule should look something like this, matching [A/B Street's 
 
 ![](https://user-images.githubusercontent.com/22789869/128907563-4aa95b30-a98d-4fbc-9275-97e0b30dd227.gif)
 
-In order to import scenario files into A/B Street, you will need to:
+After generating a `ab_scenario.json`, you can import and simulate it as follows.
 
-* Install a stable version of [Rust](https://www.rust-lang.org/tools/install)
-  + On Windows, you will also need [Visual Code Studio](https://code.visualstudio.com/) and [Visual Studio c++ build tools](https://visualstudio.microsoft.com/downloads/) prior to installing Rust.
-* On Linux, run `sudo apt-get install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libpango1.0-dev libgtk-3-dev` or the equivalent for your distribution.
-* Download the A/B Street repo `git clone https://github.com/a-b-street/abstreet.git`
-* Fetch the minimal amount of data needed to get started `cargo run --bin updater -- --minimal`
+1.  Install the [latest build](https://a-b-street.github.io/docs/user/index.html) of A/B Street for your platform.
+2.  Run the software, and choose "Sandbox" on the title screen.
+3.  If necessary, change the map to the Montlake district of Seattle, or whichever map your JSON scenario covers.
+4.  Change the scenario from the default "weekday" pattern. Choose "import JSON scenario," then select your `ab_scenario.json` file.
 
-Once you have all of this up and running, you will be able to run the scenario import.
-To start, open up a terminal in Visual Studio or your chosen IDE.
-The following commands should enable you to import your scenario.json file.
+After you successfully import this file once, it will be available in the list of scenarios, under the "Montlake Example" name, or whatever `name` specified by the JSON file.
 
-```bash
-git clone git@github.com:a-b-street/abstreet
-cp montlake_scenarios.json abstreet # or to other location 
-cd abstreet                         # or wherever you cloned the A/B Street repo
-cargo run --bin import_traffic -- \
-  --map=data/system/us/seattle/maps/montlake.bin --input=montlake_scenarios.json
-```
+You can generate scenarios for any city in the world. See [here](https://a-b-street.github.io/docs/user/new_city.html) for how to import new cities into A/B Street.
 
-Given you have correctly set the file path, the scenario should now be imported into your local version of the Montlake map. Next you can run the following command to start the A/B Street simulation in Montlake.
+Note: Instead of installing a pre-built version of A/B Street in the first step, feel free to [build from source](https://a-b-street.github.io/docs/tech/dev/index.html), but it's not necessary for any integration with the `abstr` package.
 
-```
-cargo run --bin game -- --dev data/system/us/seattle/maps/montlake.bin
-```  
+### Advanced: scripting imports
 
-Once the game has booted up click on the `scenarios` tab in the top right, it will currently be set as "none". Change this to the first option "Montlake Example" which will be the scenario we have just uploaded. Alternatively, you can skip the first import command and use the GUI to select a scenario file to import.
+If you're generating many JSON scenarios, you might not want to manually use A/B Street's user interface to import each file. You can instead run a command.
 
-To import and run data for other cities, check the [A/B Street documentation](https://a-b-street.github.io/docs).
-Scenario files used by A/B Street are documented at [a-b-street.github.io/docs in the scenarios section](https://a-b-street.github.io/docs/tech/dev/formats/scenarios.html).
-See the [Building map data](https://a-b-street.github.io/docs//tech/dev/index.html#building-map-data) documentation on getting map data loaded on your computer ready to import data for a particular city or region.
-As documented in the links above, you can import new 'scenario.json' files from the system command line as follows (requires cargo and `abstreet` as your working directory)
+1.  Install the [latest build](https://a-b-street.github.io/docs/user/index.html) of A/B Street for your platform, or [build from source](https://a-b-street.github.io/docs/tech/dev/index.html).
+2.  From the main A/B Street directory, run this command: `./cli import-scenario --input path/to/scenario.json --map data/system/us/seattle/maps/montlake.bin`
 
-```{r, include=FALSE}
-# remove generated .json file
-file.remove("montlake_scenarios.json")
-```
+If you're using Windows, you'll instead run `cli.exe`. If you're building from source, `cargo run --release --bin cli -- import-scenario --input path/to/scenario.json --map data/system/us/seattle/maps/montlake.bin`.
 
 ## Next steps
 

--- a/vignettes/abstr.Rmd
+++ b/vignettes/abstr.Rmd
@@ -22,21 +22,7 @@ To generate new scenario files to import into A/B Street with the `abstr` R pack
 
 ## Installing A/B Street
 
-Todo...
-
-## Installing Rust and the development version of A/B Street
-
--   Install a stable version of [Rust](https://www.rust-lang.org/tools/install)
-
-    -   On Windows, you will also need [Visual Code Studio](https://code.visualstudio.com/) and [Visual Studio c++ build tools](https://visualstudio.microsoft.com/downloads/) prior to installing Rust.
-
--   On Linux, run `sudo apt-get install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libpango1.0-dev libgtk-3-dev` or the equivalent for your distribution.
-
--   Download the A/B Street repo `git clone https://github.com/a-b-street/abstreet.git`
-
--   Fetch the minimal amount of data needed to get started `cargo run --bin updater -- --minimal`
-
-The example below shows how `abstr` can be used.
+Install the [latest build](https://a-b-street.github.io/docs/user/index.html) of A/B Street for your platform. Or if you prefer, [build from source](https://a-b-street.github.io/docs/tech/dev/index.html), but it's not necessary for any integration with the `abstr` package.
 
 # Using `abstr`
 
@@ -147,32 +133,14 @@ file.remove("montlake_scenarios.json")
 ```
 
 # Importing scenario files into A/B Street
-<!-- ![](https://user-images.githubusercontent.com/22789869/128907563-4aa95b30-a98d-4fbc-9275-97e0b30dd227.gif) -->
 
-In order to import scenario files into A/B Street, you will need to:
+After generating a `montlake_scenario.json`, you can import and simulate it as follows.
 
-* Install a stable version of [Rust](https://www.rust-lang.org/tools/install)
-  + On Windows, you will also need [Visual Code Studio](https://code.visualstudio.com/) and [Visual Studio c++ build tools](https://visualstudio.microsoft.com/downloads/) prior to installing Rust.
-* On Linux, run `sudo apt-get install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libpango1.0-dev libgtk-3-dev` or the equivalent for your distribution.
-* Download the A/B Street repo `git clone https://github.com/a-b-street/abstreet.git`
-* Fetch the minimal amount of data needed to get started `cargo run --bin updater -- --minimal`
+1.  Run A/B Street, and choose "Sandbox" on the title screen.
+2.  If necessary, change the map to the Montlake district of Seattle, or whichever map your JSON scenario covers.
+3.  Change the scenario from the default "weekday" pattern. Choose "import JSON scenario," then select your `montlake_scenario.json` file.
 
-Once you have all of this up and running, you will be able to run the scenario import. To start, open up a terminal in Visual Studio or your chosen IDE. Next edit the following command to include the local path of your scenario.json file.
-
-```
-cargo run --bin import_traffic -- --map=data/system/us/seattle/maps/montlake.bin --input=/path/to/input.json
-```
-
-Given you have correctly set the file path, the scenario should now be imported into your local version of the Montlake map. Next you can run the following command to start the A/B Street simulation in Montlake.
-
-```
-cargo run --bin game -- --dev data/system/us/seattle/maps/montlake.bin
-```  
-
-Once the game has booted up click on the `scenarios` tab in the top right, it will currently be set as "none". Change this to the first option "Montlake Example" which will be the scenario we have just uploaded. Alternatively, you can skip the first import command and use the GUI to select a scenario file to import.
-
-See [here](https://user-images.githubusercontent.com/22789869/128907563-4aa95b30-a98d-4fbc-9275-97e0b30dd227.gif) for a GIF of the process (watch out for a video demo).
-
+After you successfully import this file once, it will be available in the list of scenarios, under the "Montlake Example" name, or whatever `name` specified by the JSON file.
 
 # Projects supporting `abstr`
 

--- a/vignettes/activity.Rmd
+++ b/vignettes/activity.Rmd
@@ -199,28 +199,15 @@ file.remove("scenario1.json")
 
 ## Importing into A/B Street
 
-Scenario files used by A/B Street are documented at [a-b-street.github.io/docs in the scenarios section](https://a-b-street.github.io/docs/tech/dev/formats/scenarios.html).
-See the [Building map data](https://a-b-street.github.io/docs//tech/dev/index.html#building-map-data) documentation on getting map data loaded on your computer ready to import scenario files for a particular city or region.
-As documented in the links above, you can import new 'scenario.json' files from the system command line as follows (requires cargo and `abstreet` as your working directory):
-
-```bash
-git clone git@github.com:a-b-street/abstreet
-cd abstreet # or wherever you cloned the A/B Street repo
-./import.sh --raw --map --city=gb/leeds
-cargo run --bin import_traffic -- --map=data/system/gb/leeds/maps/north.bin --input=activity_leeds.json
-```
-
-Then you can run the game as follows (you can also run the game directly and import the scenario by selecting a file using the GUI):
-
-```bash
-cargo run --bin game -- --dev data/system/gb/leeds/maps/north.bin
-```
-
-Select the scenario you want with the scenario button, as shown below.
+1.  Install the [latest build](https://a-b-street.github.io/docs/user/index.html) of A/B Street for your platform.
+2.  Run the software, and choose "Sandbox" on the title screen.
+3.  Change the map to North Leeds. You can navigate by country and city, or search all maps.
+4.  Download data for Leeds, if this is your first time.
+5.  Change the scenario from the default "none" pattern, as shown below. Choose "import JSON scenario," then select your `scenario1.json` file.
 
 ![](https://user-images.githubusercontent.com/1825120/133446982-043eaad3-e832-4e7e-bcd3-2371a9094ad8.png)
 
-Tou should see something like this (see [#76](https://github.com/a-b-street/abstr/issues/76) for animated version of the image below):
+You should see something like this (see [#76](https://github.com/a-b-street/abstr/issues/76) for animated version of the image below):
 
 
 ![](https://user-images.githubusercontent.com/1825120/133152963-a57d3812-e05c-4acb-8969-5464ab2b5d74.png)
@@ -256,23 +243,4 @@ ab_save(sp_20_json, "activity_sp_20.json") # save in current folder, or:
 # ab_save(sp_20_json, "~/orgs/a-b-street/abstreet/activity_sp_20.json")
 ```
 
-As with the Leeds example, you can import the data, after saving it with `ab_save()` into the folder where you have cloned the `a-b-street/abstreet` repo, from the system command line as follows:
-
-```bash
-git clone git@github.com:a-b-street/abstreet
-cd abstreet # or wherever you cloned the A/B Street repo
-./import.sh --raw --map --city=br/sao_paulo
-cargo run --bin import_traffic -- --map=data/system/br/sao_paulo/maps/center.bin --input=activity_sp_20.json
-```
-
-Then you can run the game as follows (you can also run the game directly and import the scenario by selecting a file using the GUI):
-
-```bash
-cargo run --bin game -- --dev data/system/br/sao_paulo/maps/center.bin
-```
-
-After running the game you should see a button to change scenario as shown below.
-Clicking on this will allow you to change to a scenario you have generated with `abstr`.
-After that you should see a simulation, as shown in the GIF [here](https://twitter.com/robinlovelace/status/1438086347672236033).
-
-![](https://user-images.githubusercontent.com/1825120/133446982-043eaad3-e832-4e7e-bcd3-2371a9094ad8.png)
+As with the Leeds example, you can import the data, after saving it with `ab_save()`. Use A/B Street to download São Paulo, then import the JSON file.

--- a/vignettes/montlake.Rmd
+++ b/vignettes/montlake.Rmd
@@ -214,23 +214,10 @@ The first trip schedule should look something like this, matching [A/B Street's 
 
 ### Importing scenario files into A/B Street
 
-In order to import scenario files into A/B Street, you will need to:
+After generating a `montlake_scenario.json`, you can import and simulate it as follows.
 
-* Install a stable version of [Rust](https://www.rust-lang.org/tools/install)
-  + On Windows, you will also need [Visual Code Studio](https://code.visualstudio.com/) and [Visual Studio c++ build tools](https://visualstudio.microsoft.com/downloads/) prior to installing Rust.
-* On Linux, run `sudo apt-get install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libpango1.0-dev libgtk-3-dev` or the equivalent for your distribution.
-* Download the A/B Street repo `git clone https://github.com/a-b-street/abstreet.git`
-* Fetch the minimal amount of data needed to get started `cargo run --bin updater -- --minimal`
+1.  Run A/B Street, and choose "Sandbox" on the title screen.
+2.  If necessary, change the map to the Montlake district of Seattle, or whichever map your JSON scenario covers.
+3.  Change the scenario from the default "weekday" pattern. Choose "import JSON scenario," then select your `montlake_scenario.json` file.
 
-Once you have all of this up and running, you will be able to run the scenario import. To start, open up a terminal in Visual Studio or your chosen IDE. Next edit the following command to include the local path of your scenario.json file.
-```
-cargo run --bin import_traffic -- --map=data/system/us/seattle/maps/montlake.bin --input=/path/to/input.json
-```
-
-Given you have correctly set the file path, the scenario should now be imported into your local version of the Montlake map. Next you can run the following command to start the A/B Street simulation in Montlake.
-
-```
-cargo run --bin game -- --dev data/system/us/seattle/maps/montlake.bin
-```  
-
-Once the game has booted up click on the `scenarios` tab in the top right, it will currently be set as "none". Change this to the first option "Montlake Example" which will be the scenario we have just uploaded. Alternatively, you can skip the first import command and use the GUI to select a scenario file to import.
+After you successfully import this file once, it will be available in the list of scenarios, under the "Montlake Example" name, or whatever `name` specified by the JSON file.

--- a/vignettes/pct_to_abstr.Rmd
+++ b/vignettes/pct_to_abstr.Rmd
@@ -308,53 +308,14 @@ piggyback::pb_download_url("dutch.json")
 
 # Importing scenario files into A/B Street
 
-Given you have all of this up and running, you will be able to run the scenario import.
-AB Street contains 44 sites in England which appear in the ActDev project.
-If the local authority you have generated a scenario for is not included, follow the AB Street [documentation](https://a-b-street.github.io/docs/user/new_city.html) to import a new city.
-Next, fire up a terminal in Visual Studio or your chosen Rust IDE with the `abstreet` repo as the working directory run A/B Street as follows:
+Now that you've generated a scenario, you can simulate it. First install the [latest build](https://a-b-street.github.io/docs/user/index.html) of A/B Street for your platform. Run the software, and choose "Sandbox" on the title screen.
 
-```bash
-cargo run --bin game --release
-```
+You can then change the default map to other cities across the world. A/B Street contains over 40 sites in England from the ActDev project. If the local authority you have generated a scenario for is not included, you can also import a new city from the user interface.
 
-From there you can select the area for which data should be downloaded
-(see the A/B Street [docs on importing](https://a-b-street.github.io/docs/tech/map/importing/index.html) data for details).
-
-<!-- the scenario import tool as follows (you can check the list of maps with `ls ...`): -->
-
-Assuming you have the necessary map data the command to import the `.json` file is as follows:
-
-```bash
-cargo run --bin import_traffic -- --map=PATH/TO/MAP --input=/PATH/TO/JSON.json
-```
-
-If you used the Exeter case study and your data is located in the root directory, you can import the traffic as follows:
-
-```bash
-cargo run --bin import_traffic -- \
-  --map=data/system/gb/exeter_red_cow_village/maps/center.bin \
-  --input=dutch.json
-```
-
-Once this is done, you can fire up Fire up the AB street simulation software using the command:
-
-```bash
-cargo run --bin game -- --dev PATH/TO/MAP
-```
-
-which in the case of the Exeter example shown above is
-
-```bash
-cargo run --bin game -- --dev data/system/gb/exeter_red_cow_village/maps/center.bin
-```
-
-Once the game has booted up click on the `scenarios` tab in the top right, it will currently be set as "none".
+After loading the correct map, change the traffic scenario from the default "weekday" or "none" pattern. Choose "import JSON scenario," then select your `dutch` file.
 
 ![](https://user-images.githubusercontent.com/1825120/131586308-212caee2-3ebe-48f4-8e15-39efacedf3b4.png)
 
-Change this to the first option to "Go Dutch", or whatever you called the scenario you have just uploaded, as shown below.
-
-![](https://user-images.githubusercontent.com/1825120/131586413-c91cb53e-9b19-4d98-8e7b-d46a2f6a5845.png)
 <!-- Alternatively, you can skip the first import command and use the GUI to select a scenario file to import. -->
 <!-- In any case,  -->
 After selecting your scenario, you should see something like this, a Go Dutch scenario of cycling taking place before your eyes, making the OD data frames come to life in a real time simulation!


### PR DESCRIPTION
…ding from source. a-b-street/abstreet#745

The minimum change here is that `import_traffic` is no longer a separate command; it's been folded into one CLI tool.

But I'd also like to suggest some changes to the docs:
1) Don't instruct people to build A/B Street from source by default. I think it increases the friction to trying things out, and the pre-built version now contains the single CLI tool, which can import JSON scenarios.
2) Don't copy build instructions (like all of the `apt-get` dependencies)! That's not maintainable at all. Link to the main A/B Street docs. If those docs are wrong or confusing, let's fix them in just one place.

# TODO

I got R markdown and R studio installed, but when I try to "knit" and regenerate `README.md`, the IDE can't find the `abstr` package. I'm guessing that's because of `{r, eval=FALSE} install.packages("abstr")`. Anyway, we'd need to regenerate the `.md` file.

And if the changes here are agreeable, I'll make similar changes to the vignettes. I noticed lots of copied compilation instructions there too!